### PR TITLE
Fix scale root parsing for uncommon note names

### DIFF
--- a/src/scalesAndChords.js
+++ b/src/scalesAndChords.js
@@ -11,6 +11,10 @@ const sharpToFlat = (root) => {
     'F#': 'Gb',
     'G#': 'Ab',
     'A#': 'Bb',
+    'CB': 'B',
+    'FB': 'E',
+    'E#': 'F',
+    'B#': 'C',
   };
   return o[root.toUpperCase()] || (root.charAt(0).toUpperCase() + root.slice(1));
 };

--- a/src/scalesAndChords.test.js
+++ b/src/scalesAndChords.test.js
@@ -84,6 +84,18 @@ test('accepts sharps', () => {
   expect(scalesAndChords.chord('C#4 M')).toStrictEqual(['Db4', 'F4', 'Ab4']);
 });
 
+test('handles flats such as Cb correctly', () => {
+  expect(scalesAndChords.scale('Cb4 major')).toStrictEqual([
+    'B4',
+    'Db5',
+    'Eb5',
+    'E5',
+    'Gb5',
+    'Ab5',
+    'Bb5',
+  ]);
+});
+
 test('accepts lowercase note name', () => {
   expect(scalesAndChords.scale('c5 phrygian')).toStrictEqual([
     'C5',


### PR DESCRIPTION
## Summary
- handle enharmonic root notes like `Cb` and `E#`
- test coverage for flat roots such as `Cb`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ad81976f083298be5d65c594128dc