### PR TITLE
Fix typo in comment

### DIFF
--- a/gen/index.js
+++ b/gen/index.js
@@ -25,7 +25,7 @@ const getBitmap = ({ scale, chord }) => {
   return tonalObject.chroma;
 };
 
-// Genarate JSON file for scaleMaps
+// Generate JSON file for scaleMaps
 const scaleMaps = {};
 Scale.names().forEach((scale) => {
   scaleMaps[scale] = getBitmap({ scale });
@@ -63,7 +63,7 @@ fs.writeFile('./gen/scaleMaps.json', JSON.stringify(scaleMaps), function (err) {
   console.log('Generated scaleMaps.json');
 });
 
-// Genarate JSON file for chordMaps
+// Generate JSON file for chordMaps
 const numChords = ['4', '5', '6', '7', '9', '11', '13'];
 const chordMaps = {};
 ChordType.symbols().forEach((chord) => {


### PR DESCRIPTION
## Summary
- correct spelling in generation comments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae6fc9834832982a7d83068a9feb4