### PR TITLE
Trim scale and chord strings before processing

### DIFF
--- a/src/scalesAndChords.js
+++ b/src/scalesAndChords.js
@@ -42,11 +42,12 @@ const getChromatic = (root, octave) => {
 };
 
 const _getNotesForScaleOrChord = ({ scale, chord }) => {
-  const rootOctaveScale = scale || chord;
+  const input = scale || chord;
   const SCALE_OR_CHORD = scale ? 'scale' : 'chord';
-  if (typeof rootOctaveScale !== 'string') {
-    throw new Error(`${rootOctaveScale} is not a valid input for ${SCALE_OR_CHORD}`);
+  if (typeof input !== 'string') {
+    throw new Error(`${input} is not a valid input for ${SCALE_OR_CHORD}`);
   }
+  const rootOctaveScale = input.trim();
   const indexOfFirstSpace = rootOctaveScale.indexOf(' ');
   let scaleOrChord;
   let rootOctave;

--- a/src/scalesAndChords.test.js
+++ b/src/scalesAndChords.test.js
@@ -143,6 +143,25 @@ test('returns the notes for an inline chord if available', () => {
   ]);
 });
 
+test('trims trailing spaces in scale and chord input', () => {
+  expect(scalesAndChords.scale('C4 major ')).toStrictEqual([
+    'C4',
+    'D4',
+    'E4',
+    'F4',
+    'G4',
+    'A4',
+    'B4',
+  ]);
+
+  expect(scalesAndChords.chord('C5 maj7 ')).toStrictEqual([
+    'C5',
+    'E5',
+    'G5',
+    'B5',
+  ]);
+});
+
 test('returns the indices of the given scale by it s name or it s bitmap', () => {
   expect(scalesAndChords.getIndicesFromScale('phrygian')).toStrictEqual([0, 1,  3,  5, 7, 8, 10, 12]);
   expect(scalesAndChords.getIndicesFromScale('110101011010')).toStrictEqual([0, 1,  3,  5, 7, 8, 10, 12]);


### PR DESCRIPTION
## Summary
- trim the input string in `_getNotesForScaleOrChord`
- add unit test for trailing spaces on scale and chord

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ae6fd370c8329806d356bd3300007