### PR TITLE
Add invalid scale/chord tests and validate root notes

### DIFF
--- a/src/scalesAndChords.js
+++ b/src/scalesAndChords.js
@@ -19,26 +19,31 @@ const sharpToFlat = (root) => {
   return o[root.toUpperCase()] || (root.charAt(0).toUpperCase() + root.slice(1));
 };
 
+const CHROMATIC = [
+  'C',
+  'Db',
+  'D',
+  'Eb',
+  'E',
+  'F',
+  'Gb',
+  'G',
+  'Ab',
+  'A',
+  'Bb',
+  'B',
+];
+
 const getChromatic = (root, octave) => {
-  const o = [
-    'C',
-    'Db',
-    'D',
-    'Eb',
-    'E',
-    'F',
-    'Gb',
-    'G',
-    'Ab',
-    'A',
-    'Bb',
-    'B',
-  ];
-  const o1 = o.map((n) => n + octave);
-  const o2 = o.map((n) => n + (octave + 1));
+  const index = CHROMATIC.indexOf(root);
+  if (index === -1) {
+    throw new Error(`${root} is not a valid root note`);
+  }
+  const o1 = CHROMATIC.map((n) => n + octave);
+  const o2 = CHROMATIC.map((n) => n + (octave + 1));
 
   const c = o1.concat(o2);
-  return c.slice(c.indexOf(root + octave));
+  return c.slice(index);
 };
 
 const _getNotesForScaleOrChord = ({ scale, chord }) => {

--- a/src/scalesAndChords.test.js
+++ b/src/scalesAndChords.test.js
@@ -147,3 +147,11 @@ test('returns the indices of the given scale by it s name or it s bitmap', () =>
   expect(scalesAndChords.getIndicesFromScale('phrygian')).toStrictEqual([0, 1,  3,  5, 7, 8, 10, 12]);
   expect(scalesAndChords.getIndicesFromScale('110101011010')).toStrictEqual([0, 1,  3,  5, 7, 8, 10, 12]);
 });
+
+test('throws an error for an invalid scale', () => {
+  expect(() => scalesAndChords.scale('C4 bogus')).toThrow();
+});
+
+test('throws an error for an invalid chord', () => {
+  expect(() => scalesAndChords.chord('H# M')).toThrow();
+});


### PR DESCRIPTION
## Summary
- validate root note names in `getChromatic`
- add jest cases for invalid scale and chord inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ae6ff363083299cc703f4aba02a7e