### PR TITLE
Fix README bitmap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Get the indices of a scale/raga or bitmap
 
 ```javascript
 harmonics.getIndicesFromScale('phrygian'); // [0, 1,  3,  5, 7, 8, 10, 12]
-harmonics.inlineChord('110010110011'); // [0, 1,  3,  5, 7, 8, 10, 12]
+harmonics.getIndicesFromScale('110010110011'); // [0, 1,  3,  5, 7, 8, 10, 12]
 ```
 
 ## Security


### PR DESCRIPTION
## Summary
- fix README to use `getIndicesFromScale` for bitmap example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae6fe144c83299911ee26f98edfcb